### PR TITLE
Make library name dependent on operating system

### DIFF
--- a/src/main/java/se/hirt/memoryleaks/RunLeak.java
+++ b/src/main/java/se/hirt/memoryleaks/RunLeak.java
@@ -1,7 +1,8 @@
 package se.hirt.memoryleaks;
 
 public class RunLeak {
-	private final static String LIBRARY_NAME = "memleak";
+	private final static String LIBRARY_NAME = System.getProperty("os.name").toLowerCase().contains("win")
+			? "memleak" : "libmemleak";
 
 	static {
 		NativeUtils.loadLibrary(LIBRARY_NAME);


### PR DESCRIPTION
memleak.so couldn't be found on my linux operating system. It was called libmemleak.so.